### PR TITLE
Enable backport repos and use zfs from there

### DIFF
--- a/tasks/_setup_apt.yml
+++ b/tasks/_setup_apt.yml
@@ -1,0 +1,22 @@
+---
+- name: Setup apt proxy
+  template:
+    src: apt-proxy.j2
+    dest: /etc/apt/apt.conf.d/80-use-proxy
+    owner: root
+    group: root
+    mode: "0o644"
+  when: apt_proxy_url is defined
+
+- name: Remove default apt lists
+  file:
+    name: /etc/apt/sources.list
+    state: absent
+
+- name: Setup apt sources
+  template:
+    src: sources.list.j2
+    dest: "/etc/apt/sources.list.d/{{ ansible_distribution_release }}.list"
+    owner: root
+    group: root
+    mode: "0o644"

--- a/tasks/setup_live_environment.yml
+++ b/tasks/setup_live_environment.yml
@@ -1,23 +1,6 @@
 ---
-- name: Setup apt proxy
-  template:
-    src: apt-proxy.j2
-    dest: /etc/apt/apt.conf.d/80-use-proxy
-    owner: root
-    group: root
-    mode: "0o644"
-  when: apt_proxy_url is defined
-
-- name: Remove default apt lists
-  file:
-    name: /etc/apt/sources.list
-    state: absent
-
-- name: Enable contrib repositories
-  apt_repository:
-    repo: deb http://deb.debian.org/debian {{ ansible_distribution_release }} main contrib
-    filename: debian
-    state: present
+- name: Setup apt
+  import_tasks: tasks/_setup_apt.yml
 
 - name: Ensure all packages are up to date
   apt:
@@ -36,7 +19,11 @@
       - mokutil
       - parted
       - python3-pexpect
-      - zfs-dkms
+
+- name: Install zfs packages from backports
+  apt:
+    name: zfs-dkms
+    default_release: stable-backports
 
 - name: Ensure zfs modules are loaded
   community.general.modprobe:
@@ -48,6 +35,7 @@
 - name: Install zfs utils
   apt:
     name: zfsutils-linux
+    default_release: stable-backports
 
 - name: Configure sshd to allow connecting directly inside the chroot
   notify: Restart sshd

--- a/tasks/setup_system.yml
+++ b/tasks/setup_system.yml
@@ -32,18 +32,8 @@
     service: systemd-networkd
     enabled: true
 
-- name: Remove the default sources file
-  file:
-    path: /etc/apt/sources.list
-    state: absent
-
-- name: Setup apt sources
-  template:
-    src: sources.list.j2
-    dest: "/etc/apt/sources.list.d/{{ ansible_distribution_release }}.list"
-    owner: root
-    group: root
-    mode: "0o644"
+- name: Setup apt
+  import_tasks: tasks/_setup_apt.yml
 
 - name: Ensure all packages are up to date
   apt:
@@ -98,13 +88,18 @@
       - locales
       - openssh-server
       - sudo
-      - zfs-dkms
-      - zfs-initramfs
-      - zfs-zed
       - grub-efi-amd64
       - grub-efi-amd64-signed
       - shim-signed
     install_recommends: false
+
+- name: Install zfs packages from backports
+  apt:
+    name:
+      - zfs-dkms
+      - zfs-initramfs
+      - zfs-zed
+    default_release: stable-backports
 
 - name: Ensure the requested locale exists
   community.general.locale_gen:

--- a/templates/sources.list.j2
+++ b/templates/sources.list.j2
@@ -1,8 +1,11 @@
-deb http://deb.debian.org/debian {{ ansible_distribution_release }} main contrib
-deb-src http://deb.debian.org/debian {{ ansible_distribution_release }} main contrib
+deb http://deb.debian.org/debian {{ ansible_distribution_release }} main contrib non-free-firmware
+deb-src http://deb.debian.org/debian {{ ansible_distribution_release }} main contrib non-free-firmware
 
-deb http://security.debian.org/debian-security {{ ansible_distribution_release }}-security main contrib
-deb-src http://security.debian.org/debian-security {{ ansible_distribution_release }}-security main contrib
+deb http://security.debian.org/debian-security {{ ansible_distribution_release }}-security main contrib non-free-firmware
+deb-src http://security.debian.org/debian-security {{ ansible_distribution_release }}-security main contrib non-free-firmware
 
-deb http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib
-deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib
+deb http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib non-free-firmware
+deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib non-free-firmware
+
+deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free-firmware
+deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free-firmware


### PR DESCRIPTION
The recommendation from the ZFS team is to use it from backports on Debian, as such, let's follow that recommendation

Also include the non-free firmware repositories, as Debian does by default