### PR TITLE
Update to make the installation works with Debian Trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Debian system with an encrypted ZFS on root system.
 - ⚠️ The disk(s) can be erased. ⚠️
 - You want encryption.
 - The system supports UEFI.
-- You want Debian Buster (will not work _before_ Buster. Might work on later versions).
+- You want Debian Trixie (will not work _before_ Trixie. Might work on later versions).
 - You have ansible >2.10 installed on your system.
 - You have a wired connection on your machine.
 

--- a/inventory.yml
+++ b/inventory.yml
@@ -75,3 +75,6 @@ external:
       # Use `mkpasswd --method=sha512` to generate one otherwise.
       #
       mokutil_password: "{{ admin_password }}"
+
+      # Whether to enable backports to install ZFS or not
+      enable_backports: false

--- a/playbook.yml
+++ b/playbook.yml
@@ -36,11 +36,16 @@
     - name: Setup the system
       ansible.builtin.import_tasks: tasks/setup_system.yml
 
-
 - name: Cleanup post installation
   hosts: external
 
   tasks:
+    - name: Kill lingering ssh session
+      delegate_to: 127.0.0.1
+      ansible.builtin.command:
+        cmd: ssh -O stop root@{{ inventory_hostname }} -p 8922
+      changed_when: true
+
     - name: Unmount filesystems
       command: umount /mnt/{{ item }}
       loop:
@@ -52,6 +57,6 @@
         - sys/firmware/efi/efivars
         - sys
 
-    # FIXME: Running it with become fails?
     - name: Export zfs filesystems
-      command: sudo zpool export -a
+      become: true
+      command: zpool export -a

--- a/tasks/setup_live_environment.yml
+++ b/tasks/setup_live_environment.yml
@@ -16,14 +16,15 @@
       - debootstrap
       - dosfstools
       - gdisk
+      - linux-headers-{{ ansible_facts.kernel }}
       - mokutil
       - parted
       - python3-pexpect
 
-- name: Install zfs packages from backports
+- name: Install zfs packages
   apt:
     name: zfs-dkms
-    default_release: stable-backports
+    default_release: "{{ enable_backports | ternary(ansible_distribution_release + '-backports', omit) }}"
 
 - name: Ensure zfs modules are loaded
   community.general.modprobe:
@@ -35,7 +36,7 @@
 - name: Install zfs utils
   apt:
     name: zfsutils-linux
-    default_release: stable-backports
+    default_release: "{{ enable_backports | ternary(ansible_distribution_release + '-backports', omit) }}"
 
 - name: Configure sshd to allow connecting directly inside the chroot
   notify: Restart sshd

--- a/tasks/setup_system.yml
+++ b/tasks/setup_system.yml
@@ -51,32 +51,11 @@
     state: present
     install_recommends: false
 
-- name: Sign kernel modules on install
-  lineinfile:
-    path: /etc/dkms/framework.conf
-    regexp: '^#\s(sign_tool.*)'
-    line: '\1'
-    backrefs: true
-    state: present
-
 - name: Ensure ZFS update rebuilds all initramfs
   copy:
     dest: /etc/dkms/zfs.conf
     content: REMAKE_INITRD=yes
     mode: "0o644"
-
-- name: Create key to sign kernel modules
-  command: |
-    openssl \
-      req \
-      -nodes \
-      -new -x509 -newkey rsa:2048 \
-      -keyout /root/mok.priv \
-      -outform DER -out /root/mok.der \
-      -days 36500 \
-      -subj "/CN={{ fqdn }} module signing key/"
-  args:
-    creates: /root/mok.priv
 
 - name: Install required packages
   apt:
@@ -93,13 +72,13 @@
       - shim-signed
     install_recommends: false
 
-- name: Install zfs packages from backports
+- name: Install zfs packages
   apt:
     name:
       - zfs-dkms
       - zfs-initramfs
       - zfs-zed
-    default_release: stable-backports
+    default_release: "{{ enable_backports | ternary(ansible_distribution_release + '-backports', omit) }}"
 
 - name: Ensure the requested locale exists
   community.general.locale_gen:
@@ -200,13 +179,6 @@
     group: root
     mode: "0o644"
 
-- name: Ensure we have /tmp on a tmpfs
-  file:
-    src: /usr/share/systemd/tmp.mount
-    dest: /etc/systemd/system/tmp.mount
-    state: link
-    mode: "0o644"
-
 - name: Enable the /tmp tmpfs mount service
   systemd:
     service: tmp.mount
@@ -239,13 +211,7 @@
   command: update-grub
 
 - name: Install grub
-  command: >
-    grub-install \
-    --target=x86_64-efi \
-    --efi-directory=/boot/efi \
-    --bootloader-id=debian \
-    --recheck \
-    --no-floppy
+  command: grub-install
 
 - name: Create temporary file to contain the hash for mokutil password
   tempfile:
@@ -262,7 +228,7 @@
     group: root
 
 - name: Import the generated Secure boot key
-  command: mokutil --hash-file "{{ _mokutil_file.path }}" --import /root/mok.der
+  command: mokutil --hash-file "{{ _mokutil_file.path }}" --import /var/lib/dkms/mok.pub
 
 - name: Snapshot the filesystems before boot
   community.general.zfs:

--- a/templates/sources.list.j2
+++ b/templates/sources.list.j2
@@ -7,5 +7,7 @@ deb-src http://security.debian.org/debian-security {{ ansible_distribution_relea
 deb http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib non-free-firmware
 deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-updates main contrib non-free-firmware
 
+{%- if enable_backports -%}
 deb http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free-firmware
 deb-src http://deb.debian.org/debian {{ ansible_distribution_release }}-backports main contrib non-free-firmware
+{%- endif -%}


### PR DESCRIPTION
This does the minimal changes so that it will work with Trixie while still unreleased.

- Some cleanups for things that now work under trixie
- simplified mok key management, one is generated by debian by default now
- simplified grub installation
- ability to disable backports