### PR TITLE
Use systemd-boot and get rid of the bpool

### DIFF
--- a/playbooks/tasks/install_system.yml
+++ b/playbooks/tasks/install_system.yml
@@ -8,26 +8,16 @@
     device: /dev/{{ item }}
     number: 1
     state: present
-    part_end: 2GiB
+    part_end: 5GiB
     label: gpt
     flags:
       - esp
   loop: "{{ root_disks }}"
 
-- name: Create boot pool partitions
-  community.general.parted:
-    device: /dev/{{ item }}
-    number: 2
-    state: present
-    part_start: 2GiB
-    part_end: 5GiB
-    label: gpt
-  loop: "{{ root_disks }}"
-
 - name: Create root pool partitions
   community.general.parted:
     device: /dev/{{ item }}
-    number: 3
+    number: 2
     state: present
     part_start: 5GiB
     label: gpt
@@ -50,41 +40,6 @@
     opts: -F 32 -s 1 -n EFI
     dev: "/dev/disk/by-id/{{ ansible_facts.devices[item].partitions[item + '1'].links.ids[0] }}"
   loop: "{{ root_disks }}"
-
-- name: Create the zfs bpool pool
-  when: "'bpool' not in zfs_pools_names"
-  ansible.builtin.command: >
-    zpool create
-      -d
-      -f
-      -o ashift=12
-      -o cachefile=none
-      -o feature@async_destroy=enabled
-      -o feature@bookmarks=enabled
-      -o feature@embedded_data=enabled
-      -o feature@empty_bpobj=enabled
-      -o feature@enabled_txg=enabled
-      -o feature@extensible_dataset=enabled
-      -o feature@filesystem_limits=enabled
-      -o feature@hole_birth=enabled
-      -o feature@large_blocks=enabled
-      -o feature@lz4_compress=enabled
-      -o feature@spacemap_histogram=enabled
-      -o feature@zpool_checkpoint=enabled
-      -O acltype=posixacl
-      -O canmount=off
-      -O compression=lz4
-      -O devices=off
-      -O normalization=formD
-      -O relatime=on
-      -O xattr=sa
-      -O mountpoint=/boot
-      -R /mnt
-      bpool
-      {{ pool_mode | default() }}
-      {% for disk in root_disks %}
-        {{ ansible_facts.devices[disk].partitions[disk + "2"].links.ids[0] }}
-      {% endfor %}
 
 - name: Create the zfs rpool pool
   when: "'rpool' not in zfs_pools_names"
@@ -109,7 +64,7 @@
         rpool
         {{ pool_mode | default() }}
         {% for disk in root_disks %}
-          {{ ansible_facts.devices[disk].partitions[disk + "3"].links.ids[0] }}
+          {{ ansible_facts.devices[disk].partitions[disk + "2"].links.ids[0] }}
         {% endfor %}
     responses:
       Enter new passphrase: "{{ zfs_pool_password }}"
@@ -117,14 +72,11 @@
 
 - name: Create root zfs mountpoints
   community.general.zfs:
-    name: "{{ item }}"
+    name: rpool/ROOT
     state: present
     extra_zfs_properties:
       canmount: false
       mountpoint: none
-  loop:
-    - rpool/ROOT
-    - bpool/BOOT
 
 - name: Create distribution specific root mountpoint
   community.general.zfs:
@@ -137,19 +89,19 @@
 - name: Mount the root filesystem
   ansible.builtin.command: zfs mount rpool/ROOT/{{ zfs_system_root_name }}
 
-- name: Create distribution specific boot mountpoint
-  community.general.zfs:
-    name: "bpool/BOOT/{{ zfs_system_root_name }}"
-    state: present
-    extra_zfs_properties:
-      mountpoint: /boot
-
 - name: Create zfs volumes
   community.general.zfs:
     name: rpool/{{ item.name }}
     state: present
     extra_zfs_properties: "{{ item.properties | default({}) }}"
   loop:
+    - name: BOOT
+      properties:
+        canmount: false
+        mountpoint: none
+    - name: BOOT/{{ zfs_system_root_name }}
+      properties:
+        mountpoint: /boot
     - name: home
     - name: home/root
       properties:
@@ -163,11 +115,7 @@
     - name: var/log
     - name: var/spool
     - name: var/cache
-      properties:
-        com.sun:auto-snapshot: false
     - name: var/tmp
-      properties:
-        com.sun:auto-snapshot: false
 
 - name: Ensure /mnt/var/tmp has the right permissions
   ansible.builtin.file:

--- a/playbooks/tasks/setup_system.yml
+++ b/playbooks/tasks/setup_system.yml
@@ -68,11 +68,11 @@
       - man-db
       - openssh-server
       - sudo
-      - grub-efi-amd64
-      - grub-efi-amd64-signed
       - shim-signed
+      - systemd-boot
       - systemd-resolved
       - tmux
+      - zstd
     install_recommends: false
 
 - name: Install zfs packages
@@ -215,20 +215,14 @@
     mode: "0o600"
   when: ssh_port != 22
 
+- name: Generate the proper cmdline configuration
+  ansible.builtin.copy:
+    content: root=ZFS=rpool/ROOT/debian-trixie boot=zfs
+    dest: /etc/kernel/cmdline
+    mode: "0o644"
+
 - name: Update the initramfs
   ansible.builtin.command: update-initramfs -c -k all
-
-- name: Tell grub where the root is
-  ansible.builtin.lineinfile:
-    path: /etc/default/grub
-    regexp: '^GRUB_CMDLINE_LINUX='
-    line: 'GRUB_CMDLINE_LINUX="root=ZFS=rpool/ROOT/{{ zfs_system_root_name }}"'
-
-- name: Update grub configuration files
-  ansible.builtin.command: update-grub
-
-- name: Install grub
-  ansible.builtin.command: grub-install
 
 - name: Create temporary file to contain the hash for mokutil password
   ansible.builtin.tempfile:
@@ -250,10 +244,5 @@
     - molecule-notest
 
 - name: Snapshot the filesystems before boot
-  community.general.zfs:
-    name: "{{ item }}@install"
-    state: present
-  loop:
-    - rpool/ROOT/{{ zfs_system_root_name }}
-    - bpool/BOOT/{{ zfs_system_root_name }}
-    - rpool/var
+  ansible.builtin.command:
+    cmd: zfs snapshot -r rpool@install


### PR DESCRIPTION
We don't need this anymore, we can have the kernel on /boot/efi with systemd-boot