### PR TITLE
Use pinned preferences for zfs using backports

### DIFF
--- a/playbooks/tasks/_setup_apt.yml
+++ b/playbooks/tasks/_setup_apt.yml
@@ -39,3 +39,23 @@
     suites: "{{ ansible_facts.distribution_release }}-security"
     components: main contrib
     signed_by: /usr/share/keyrings/debian-archive-keyring.gpg
+
+- name: Configure backports
+  become: true
+  when: enable_backports
+  ansible.builtin.copy:
+    content: |
+      Package: {{ item }}
+      Pin: release a=stable-backports
+      Pin-Priority: 990
+    dest: /etc/apt/preferences.d/backports-{{ item }}
+    mode: "0o644"
+  loop:
+    - libnvpair3linux
+    - libuutil3linux
+    - libzfs6linux
+    - libzpool6linux
+    - zfsutils-linux
+    - zfs-dkms
+    - zfs-initramfs
+    - zfs-zed

--- a/playbooks/tasks/setup_live_environment.yml
+++ b/playbooks/tasks/setup_live_environment.yml
@@ -25,7 +25,6 @@
 - name: Install zfs packages
   ansible.builtin.apt:
     name: zfs-dkms
-    default_release: "{{ enable_backports | ternary(ansible_facts.distribution_release + '-backports', omit) }}"
 
 - name: Ensure zfs modules are loaded
   community.general.modprobe:
@@ -37,7 +36,6 @@
 - name: Install zfs utils
   ansible.builtin.apt:
     name: zfsutils-linux
-    default_release: "{{ enable_backports | ternary(ansible_facts.distribution_release + '-backports', omit) }}"
 
 - name: Configure sshd to allow connecting directly inside the chroot
   notify: Restart sshd

--- a/playbooks/tasks/setup_system.yml
+++ b/playbooks/tasks/setup_system.yml
@@ -81,7 +81,6 @@
       - zfs-dkms
       - zfs-initramfs
       - zfs-zed
-    default_release: "{{ enable_backports | ternary(ansible_facts.distribution_release + '-backports', omit) }}"
 
 - name: Ensure the requested locale exists
   community.general.locale_gen:


### PR DESCRIPTION
This makes it better on the long run as it ensures we keep getting the backport updates for zfs and its dependencies