### PR TITLE
Allow devices to be mounted on /var/tmp

### DIFF
--- a/playbooks/tasks/install_system.yml
+++ b/playbooks/tasks/install_system.yml
@@ -143,7 +143,6 @@
     - name: var/tmp
       properties:
         mountpoint: /var/tmp
-        devices: false
         exec: false
         setuid: false
 


### PR DESCRIPTION
This is necessary for podman to work properly