### PR TITLE
Reorder the home directory setup for the admin user

### DIFF
--- a/playbooks/tasks/setup_system.yml
+++ b/playbooks/tasks/setup_system.yml
@@ -111,14 +111,6 @@
       - adm
       - sudo
 
-- name: Ensure the permissions on the admin home directory are correct
-  ansible.builtin.file:
-    path: /home/{{ admin_username }}
-    mode: "0o700"
-    owner: "{{ admin_username }}"
-    group: "{{ admin_username }}"
-    state: directory
-
 - name: Copy the skeleton files for the user
   ansible.builtin.copy:
     src: /etc/skel/
@@ -127,6 +119,14 @@
     owner: "{{ admin_username }}"
     group: "{{ admin_username }}"
     mode: preserve
+
+- name: Ensure the permissions on the admin home directory are correct
+  ansible.builtin.file:
+    path: /home/{{ admin_username }}
+    mode: "0o700"
+    owner: "{{ admin_username }}"
+    group: "{{ admin_username }}"
+    state: directory
 
 - name: Set authorized key taken for the admin user
   ansible.posix.authorized_key:


### PR DESCRIPTION
Otherwise the home directory gets the permissions of the skel directory which are too wide open