### PR TITLE
Mount /var/log as a legacy filesystem

### DIFF
--- a/extensions/molecule/default/verify.yml
+++ b/extensions/molecule/default/verify.yml
@@ -32,9 +32,9 @@
 
     - name: Ensure the fstab contains the expected number of lines
       ansible.builtin.assert:
-        that: (fstab.content | b64decode | regex_findall("\\S.*") | length) == (root_disks | length + 1)
+        that: (fstab.content | b64decode | regex_findall("\\S.*") | length) == (root_disks | length + 2)
         msg: |
-          Expected {{ root_disks | length + 1 }} entries in fstab. Got {{ fstab.content | b64decode | regex_findall("\\S.*") | length }} instead:
+          Expected {{ root_disks | length + 2 }} entries in fstab. Got {{ fstab.content | b64decode | regex_findall("\\S.*") | length }} instead:
           ---
           {{ fstab.content | b64decode }}
           ---

--- a/playbooks/tasks/install_system.yml
+++ b/playbooks/tasks/install_system.yml
@@ -89,7 +89,7 @@
 - name: Mount the root filesystem
   ansible.builtin.command: zfs mount rpool/ROOT/debian
 
-- name: Create zfs volumes
+- name: Create var zfs volumes
   community.general.zfs:
     name: rpool/var
     state: present
@@ -98,12 +98,25 @@
       devices: false
       setuid: false
 
-- name: Mount /mnt/var
+- name: Create var/log zfs volume
+  community.general.zfs:
+    name: rpool/var/log
+    state: present
+    extra_zfs_properties:
+      mountpoint: legacy
+      devices: false
+      exec: false
+      setuid: false
+
+- name: Mount legacy filesystems
   ansible.posix.mount:
-    src: rpool/var
-    path: /mnt/var
+    src: rpool/{{ item }}
+    path: /mnt/{{ item }}
     fstype: zfs
     state: mounted
+  loop:
+    - var
+    - var/log
 
 - name: Create zfs volumes
   community.general.zfs:
@@ -128,12 +141,6 @@
         mountpoint: /root
         setuid: false
     - name: home/{{ admin_username }}
-    - name: var/log
-      properties:
-        mountpoint: /var/log
-        devices: false
-        exec: false
-        setuid: false
     - name: var/spool
       properties:
         mountpoint: /var/spool

--- a/playbooks/tasks/setup_system.yml
+++ b/playbooks/tasks/setup_system.yml
@@ -235,6 +235,7 @@
       {% endfor %}
       {%- endif -%}
       rpool/var /var zfs x-systemd.before=zfs-mount.service 0 0
+      rpool/var/log /var/log zfs x-systemd.before=zfs-mount.service 0 0
     # yamllint enable rule:line-length
     dest: /etc/fstab
     mode: "0o644"


### PR DESCRIPTION
Otherwise, journald receives the flush before it is actually mounted, leading the logs to be stored in the parent filesystem